### PR TITLE
Add waypoint follower

### DIFF
--- a/ora_description/rviz/config.rviz
+++ b/ora_description/rviz/config.rviz
@@ -5,14 +5,15 @@ Panels:
     Property Tree Widget:
       Expanded: ~
       Splitter Ratio: 0.5029411911964417
-    Tree Height: 719
+    Tree Height: 685
   - Class: rviz_common/Views
     Expanded:
       - /Current View1
     Name: Views
     Splitter Ratio: 0.5
   - Class: rviz_common/Views
-    Expanded: ~
+    Expanded:
+      - /Current View1
     Name: Views
     Splitter Ratio: 0.5
 Visualization Manager:
@@ -67,6 +68,10 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
+        camera_link_optical:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
         chassis_link:
           Alpha: 1
           Show Axes: false
@@ -138,6 +143,8 @@ Visualization Manager:
           Value: true
         camera_link:
           Value: true
+        camera_link_optical:
+          Value: true
         chassis_link:
           Value: true
         gnss_link:
@@ -171,7 +178,8 @@ Visualization Manager:
             base_footprint:
               {}
             camera_link:
-              {}
+              camera_link_optical:
+                {}
             chassis_link:
               {}
             gnss_link:
@@ -295,7 +303,7 @@ Visualization Manager:
       Use Fixed Frame: true
       Use rainbow: false
       Value: true
-    - Alpha: 0.699999988079071
+    - Alpha: 0.30000001192092896
       Binary representation: false
       Binary threshold: 100
       Class: rviz_default_plugins/Map
@@ -303,6 +311,29 @@ Visualization Manager:
       Draw Behind: false
       Enabled: true
       Name: Global Costmap
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /global_costmap/costmap
+      Update Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /global_costmap/costmap_updates
+      Use Timestamp: false
+      Value: true
+    - Alpha: 0.699999988079071
+      Binary representation: false
+      Binary threshold: 100
+      Class: rviz_default_plugins/Map
+      Color Scheme: costmap
+      Draw Behind: false
+      Enabled: true
+      Name: Local Costmap
       Topic:
         Depth: 5
         Durability Policy: Volatile
@@ -359,6 +390,34 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /plan
       Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz_default_plugins/Path
+      Color: 0; 255; 255
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Look Ahead
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /lookahead_collision_arc
+      Value: true
     - Class: rviz_default_plugins/Image
       Enabled: false
       Max Value: 1
@@ -383,7 +442,7 @@ Visualization Manager:
       Channel Name: intensity
       Class: rviz_default_plugins/PointCloud2
       Color: 255; 255; 255
-      Color Transformer: RGB8
+      Color Transformer: Intensity
       Decay Time: 0
       Enabled: false
       Invert Rainbow: false
@@ -391,7 +450,7 @@ Visualization Manager:
       Max Intensity: 4096
       Min Color: 0; 0; 0
       Min Intensity: 0
-      Name: PointCloud2
+      Name: Lines
       Position Transformer: XYZ
       Selectable: true
       Size (Pixels): 3
@@ -402,7 +461,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /depth_camera/points
+        Value: /depth_camera/filtered/points
       Use Fixed Frame: true
       Use rainbow: true
       Value: false
@@ -453,11 +512,11 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Scale: 100
+      Scale: 90.03439331054688
       Target Frame: base_link
       Value: TopDownOrtho (rviz_default_plugins)
-      X: 0
-      Y: 0
+      X: -1.392691731452942
+      Y: -0.646464467048645
     Saved:
       - Angle: 4.710000038146973
         Class: rviz_default_plugins/TopDownOrtho
@@ -482,9 +541,9 @@ Window Geometry:
   Hide Right Dock: false
   Image:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000100000000000001e600000415fc0200000005fb000000100044006900730070006c006100790073010000003b00000358000000c700fffffffb0000000a0049006d00610067006500000002d7000001790000001600fffffffb0000000c00430061006d00650072006101000004320000018a0000000000000000fb0000000a005600690065007700730000000373000000dd000000a000fffffffb0000000a005600690065007700730100000399000000b7000000a000ffffff000005520000041500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000100000000000001e600000415fc0200000005fb000000100044006900730070006c006100790073010000003b00000336000000c700fffffffb0000000a0049006d006100670065000000029f0000010b0000001600fffffffb0000000c00430061006d00650072006101000004320000018a0000000000000000fb0000000a005600690065007700730000000373000000dd000000a000fffffffb0000000a005600690065007700730100000377000000d9000000a000ffffff000005520000041500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Views:
     collapsed: false
   Width: 1854
-  X: 2086
-  Y: 195
+  X: 2054
+  Y: 163

--- a/ora_navigation/CMakeLists.txt
+++ b/ora_navigation/CMakeLists.txt
@@ -7,10 +7,12 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
-# uncomment the following section in order to fill in
-# further dependencies manually.
-# find_package(<dependency> REQUIRED)
+find_package(rclcpp REQUIRED)
 
+add_executable(gps_waypoint_follower src/gps_waypoint_follower.cpp)
+ament_target_dependencies(gps_waypoint_follower
+  rclcpp
+)
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
@@ -27,6 +29,11 @@ install(DIRECTORY
   config
   launch
   DESTINATION share/${PROJECT_NAME}/
+)
+
+install(TARGETS
+  gps_waypoint_follower
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 ament_package()

--- a/ora_navigation/CMakeLists.txt
+++ b/ora_navigation/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
@@ -19,8 +20,9 @@ find_package(yaml-cpp REQUIRED)
 
 add_executable(gps_waypoint_follower src/gps_waypoint_follower.cpp)
 ament_target_dependencies(gps_waypoint_follower
-  rclcpp ament_index_cpp std_msgs std_srvs fusioncore_ros geographic_msgs geometry_msgs
+  rclcpp rclcpp_action ament_index_cpp std_msgs std_srvs  geographic_msgs geometry_msgs
   nav2_msgs
+  fusioncore_ros
 )
 
 target_link_libraries(gps_waypoint_follower

--- a/ora_navigation/CMakeLists.txt
+++ b/ora_navigation/CMakeLists.txt
@@ -8,11 +8,25 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(ament_index_cpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(fusioncore_ros REQUIRED)
+find_package(geographic_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(nav2_msgs REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 add_executable(gps_waypoint_follower src/gps_waypoint_follower.cpp)
 ament_target_dependencies(gps_waypoint_follower
-  rclcpp
+  rclcpp ament_index_cpp std_msgs std_srvs fusioncore_ros geographic_msgs geometry_msgs
+  nav2_msgs
 )
+
+target_link_libraries(gps_waypoint_follower
+  yaml-cpp
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights

--- a/ora_navigation/config/nav2_params.yaml
+++ b/ora_navigation/config/nav2_params.yaml
@@ -1,27 +1,6 @@
 # nav2_params.yaml: FusionCore + Nav2 reference configuration
-#
-# Designed for: outdoor GPS navigation, differential-drive robot
-# Tested with:  Clearpath Husky A200, ROS 2 Jazzy, Nav2 Jazzy
-#
-# FusionCore publishes:
-#   /fusion/odom         (nav_msgs/Odometry, 100 Hz)
-#   TF: odom → base_link (100 Hz, GPS-corrected: odom origin anchored to first GPS fix)
-#
-# What to change for your robot:
-#   robot_radius          → half the widest dimension (or use footprint polygon)
-#   max_vel_x             → your platform's max forward speed
-#   min_vel_x_backwards   → set 0.0 to prevent reversing
-#   base_frame_id         → must match fusioncore.yaml base_frame
-#
-# Usage:
-#   ros2 launch fusioncore_ros fusioncore_nav2.launch.py \
-#     fusioncore_config:=<your_robot>.yaml \
-#     nav2_params:=$(ros2 pkg prefix fusioncore_ros)/share/fusioncore_ros/config/nav2_params.yaml
-#
-# For Clearpath Husky, also remap:
-#   --ros-args -r /odom/wheels:=/husky_velocity_controller/odom -r /gnss/fix:=/fix
 
-# ── Behaviour Tree navigator ───────────────────────────────────────────────────
+# ── Behaviour Tree Navigator ──────────────────────────────────────────────────
 bt_navigator:
   ros__parameters:
     use_sim_time: true
@@ -38,7 +17,7 @@ bt_navigator:
     navigate_through_poses:
       plugin: "nav2_bt_navigator::NavigateThroughPosesNavigator"
 
-# ── Planner: NavFn (global A* path) ───────────────────────────────────────────
+# ── Planner: NavFn (Global A*) ────────────────────────────────────────────────
 planner_server:
   ros__parameters:
     use_sim_time: true
@@ -49,9 +28,8 @@ planner_server:
       use_astar: true         # A* over Dijkstra for outdoor long-range
       allow_unknown: true     # plan through unexplored space (GPS-nav, no lidar map needed)
 
-# ── Controller: Regulated Pure Pursuit ────────────────────────────────────────
-# RPP works well outdoors with GPS: smooth, predictable, handles long straight runs.
-# For tight indoor spaces, switch to DWB (plugin: "dwb_core::DWBLocalPlanner").
+# ── Controller Server (RPP) ───────────────────────────────────────────────────
+# 
 controller_server:
   ros__parameters:
     use_sim_time: true
@@ -62,7 +40,7 @@ controller_server:
     min_theta_velocity_threshold: 0.001
     failure_tolerance: 0.3
     progress_checker_plugin: "progress_checker"
-    goal_checker_plugins: ["general_goal_checker"]
+    goal_checker_plugins: ["position_goal_checker"]
     controller_plugins: ["FollowPath"]
 
     progress_checker:
@@ -70,20 +48,20 @@ controller_server:
       required_movement_radius: 0.5
       movement_time_allowance: 10.0
 
-    general_goal_checker:
+    position_goal_checker:
       stateful: true
-      plugin: "nav2_controller::SimpleGoalChecker"
-      xy_goal_tolerance: 0.5      # m: relax for GPS-accuracy navigation
-      yaw_goal_tolerance: 0.25    # rad
+      plugin: "nav2_controller::PositionGoalChecker"
+      xy_goal_tolerance: 0.5      # Tolerance to meet goal completion criteria (m).
+      path_length_tolerance: 0.5  # Tolerance to meet goal completion criteria (m).
 
     FollowPath:
       plugin: "nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"
-      desired_linear_vel: 0.5     # m/s: set to your comfortable cruise speed
-      lookahead_dist: 1.5         # m: increase for faster/smoother outdoor driving
+      desired_linear_vel: 1.0     # m/s: set to your comfortable cruise speed
+      lookahead_dist: 3.0         # m: increase for faster/smoother outdoor driving
       min_lookahead_dist: 0.8
       max_lookahead_dist: 3.0
       lookahead_time: 1.5
-      rotate_to_heading_angular_vel: 0.5   # rad/s
+      rotate_to_heading_angular_vel: 1.5
       transform_tolerance: 0.1
       use_velocity_scaled_lookahead_dist: true
       min_approach_linear_velocity: 0.05
@@ -99,10 +77,11 @@ controller_server:
       use_rotate_to_heading: true     # rotate in place before starting: safe for GPS nav
       allow_reversing: false
       rotate_to_heading_min_angle: 0.785  # ~45 deg: only rotate if heading error > this
-      max_angular_accel: 1.5
+      max_angular_accel: 3.0
       max_robot_pose_search_dist: 10.0
 
 # ── Smoother ──────────────────────────────────────────────────────────────────
+# Smooth velocity outputs from Nav
 velocity_smoother:
   ros__parameters:
     use_sim_time: true
@@ -110,20 +89,17 @@ velocity_smoother:
     smoothing_frequency: 20.0
     scale_velocities: false
     feedback: "OPEN_LOOP"
-    odom_topic: /fusion/odom        # must point to FusionCore's odometry output
+    odom_topic: /fusion/odom
     odom_duration: 0.1
     deadband_velocity: [0.0, 0.0, 0.0]
     velocity_timeout: 1.0
     max_velocity:     [ 2.2, 0.0,  2.2]  # [x m/s, y m/s, yaw rad/s]
-    min_velocity:     [-0.5, 0.0, -1.0]
+    min_velocity:     [-1.0, 0.0, -2.2]
     max_accel:        [ 0.5, 0.0,  1.5]
     max_decel:        [-0.5, 0.0, -1.5]
 
-# ── Costmaps ──────────────────────────────────────────────────────────────────
-# GPS-only navigation: no static map, no lidar.
-# Both costmaps use only the robot's footprint (inflation) and optional sensor layers.
-# If you have a lidar, add an obstacle_layer: see comment below.
-
+# ── Local Costmap ────────────────────────────────────────────────────────────
+# Used for local plan
 local_costmap:
   local_costmap:
     ros__parameters:
@@ -133,9 +109,10 @@ local_costmap:
       global_frame: odom
       robot_base_frame: base_link
       rolling_window: true
-      width:  8        # m: local planning window
+      width:  8
       height: 8
       resolution: 0.05
+      # TODO: Update footprint to match robot
       footprint: "[[0.54, 0.34], [0.54, -0.34], [-0.331, -0.34], [-0.331, 0.34]]"
       plugins: ["obstacle_layer", "inflation_layer"]
       obstacle_layer:
@@ -155,9 +132,11 @@ local_costmap:
       inflation_layer:
         plugin: "nav2_costmap_2d::InflationLayer"
         cost_scaling_factor: 3.0
-        inflation_radius: 0.4   # m: pad around robot for obstacle clearance
+        inflation_radius: 0.4
       always_send_full_costmap: true
 
+# ── Global Costmap ────────────────────────────────────────────────────────────
+# Used to create global plan
 global_costmap:
   global_costmap:
     ros__parameters:
@@ -167,11 +146,12 @@ global_costmap:
       global_frame: odom
       robot_base_frame: base_link
       rolling_window: true
-      width: 40
-      height: 40
+      width: 80
+      height: 80
       resolution: 0.1
+      # TODO: Update footprint to match robot
       footprint: "[[0.54, 0.34], [0.54, -0.34], [-0.331, -0.34], [-0.331, 0.34]]"
-      track_unknown_space: false     # true = plan through unknown (GPS-nav mode)
+      track_unknown_space: false
       plugins: ["obstacle_layer", "inflation_layer"]
       obstacle_layer:
         plugin: "nav2_costmap_2d::ObstacleLayer"
@@ -192,16 +172,15 @@ global_costmap:
         inflation_radius: 0.5
       always_send_full_costmap: false
 
-# ── Map server (empty map for GPS-only navigation) ────────────────────────────
-# FusionCore provides absolute GPS positioning: no lidar map needed.
-# This publishes a 100m × 100m empty costmap as the global map.
-# If you have a real map (pgm/yaml), point map_server here instead.
+# ── Map Server ────────────────────────────────────────────────────────────────
+# No map available 
 map_server:
   ros__parameters:
     use_sim_time: true
-    yaml_filename: ""      # leave empty: map_server not needed for GPS-only nav
+    yaml_filename: ""
 
-# ── Behaviour server (recovery behaviours) ────────────────────────────────────
+# ── Behavior Server ───────────────────────────────────────────────────────────
+# Recovery behaviors
 behavior_server:
   ros__parameters:
     use_sim_time: true
@@ -209,24 +188,27 @@ behavior_server:
     costmap_topic: local_costmap/costmap_raw
     footprint_topic: local_costmap/published_footprint
     cycle_frequency: 10.0
-    behavior_plugins: ["backup", "spin", "drive_on_heading", "wait"]
+    behavior_plugins: ["backup", "drive_on_heading", "wait", "spin"]
     backup:
       plugin: "nav2_behaviors::BackUp"
-    spin:
-      plugin: "nav2_behaviors::Spin"
     drive_on_heading:
       plugin: "nav2_behaviors::DriveOnHeading"
     wait:
       plugin: "nav2_behaviors::Wait"
+    spin:
+      plugin: "nav2_behaviors::Spin"
     local_frame: odom
     global_frame: odom
     robot_base_frame: base_link
     transform_tolerance: 0.1
     simulate_ahead_time: 2.0
-    max_rotational_vel: 0.5
-    min_rotational_vel: 0.1
-    rotational_acc_lim: 1.5
+    max_rotational_vel: 1.2
+    min_rotational_vel: 0.2
+    rotational_acc_lim: 3.0
 
+# ── Collision Monitor ─────────────────────────────────────────────────────────
+# Checks whether the robot is going to collide with an obstacle
+# Using lidar and lane lines as collidables
 collision_monitor:
   ros__parameters:
     base_frame_id: "base_link"
@@ -239,8 +221,6 @@ collision_monitor:
     source_timeout: 1.0
     base_shift_correction: True
     stop_pub_timeout: 2.0
-    # Polygons represent zone around the robot for "stop", "slowdown" and "limit" action types,
-    # and robot footprint for "approach" action type.
     polygons: ["FootprintApproach"]
     FootprintApproach:
       type: "polygon"
@@ -259,6 +239,10 @@ collision_monitor:
       max_height: 2.0
       enabled: True
 
+# ── Docking Server ────────────────────────────────────────────────────────────
+# Unused
+# Nav2 required the docking server to be in the nav2_params file to launch the
+# bringup.
 docking_server:
   ros__parameters:
     controller_frequency: 50.0
@@ -273,7 +257,6 @@ docking_server:
     dock_backwards: false
     dock_prestaging_tolerance: 0.5
 
-    # Types of docks
     dock_plugins: ['simple_charging_dock']
     simple_charging_dock:
       plugin: 'opennav_docking::SimpleChargingDock'
@@ -291,14 +274,6 @@ docking_server:
       external_detection_rotation_yaw: 0.0
       filter_coef: 0.1
 
-    # Dock instances
-    # The following example illustrates configuring dock instances.
-    # docks: ['home_dock']  # Input your docks here
-    # home_dock:
-    #   type: 'simple_charging_dock'
-    #   frame: map
-    #   pose: [0.0, 0.0, 0.0]
-
     controller:
       k_phi: 3.0
       k_delta: 2.0
@@ -312,7 +287,7 @@ docking_server:
       simulation_step: 0.1
       dock_collision_threshold: 0.3
 
-# ── Lifecycle managers ────────────────────────────────────────────────────────
+# ── Lifecycle Manager ─────────────────────────────────────────────────────────
 lifecycle_manager_navigation:
   ros__parameters:
     use_sim_time: true

--- a/ora_navigation/config/waypoints.yaml
+++ b/ora_navigation/config/waypoints.yaml
@@ -1,0 +1,25 @@
+---
+practice_course:
+  - name: north
+    lat: 42.668212
+    lon: -83.218459
+  - name: mid
+    lat: 42.668086
+    lon: -83.218446
+  - name: south
+    lat: 42.66796
+    lon: -83.218433
+
+main_course:
+  - name: north
+    lat: 42.66827
+    lon: -83.21934
+  - name: north_ramp
+    lat: 42.668121
+    lon: -83.219361
+  - name: south_ramp
+    lat: 42.668077
+    lon: -83.219359
+  - name: south
+    lat: 42.667928
+    lon: -83.219328

--- a/ora_navigation/include/gps_waypoint_follower.hpp
+++ b/ora_navigation/include/gps_waypoint_follower.hpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <vector>
 #include <yaml-cpp/yaml.h>
 
 #include "rclcpp/rclcpp.hpp"
@@ -18,58 +19,101 @@
 
 #include "std_srvs/srv/set_bool.hpp"
 #include "std_srvs/srv/trigger.hpp"
+#include "action_msgs/srv/cancel_goal.hpp"
 
 class GpsWaypointFollower : public rclcpp::Node
 {
-  public:
-    GpsWaypointFollower();
+public:
+  GpsWaypointFollower();
 
-  private:
-    void initialize(const YAML::Node& config);
-    void loadWaypoints(const YAML::Node& waypoint_group, std::vector<geographic_msgs::msg::GeoPoint>& destination_vector);
-    void transformNextWaypoint();
+private:
+  using NavigateToPose = nav2_msgs::action::NavigateToPose;
 
-    void startNavigation();
-    void stopNavigation();
-    void resetNavigation();
-    void navigateToWaypoint(const geometry_msgs::msg::Point& localized_waypoint);
+  // Setup / Loading
+  void initialize(const YAML::Node& config);
+  void loadWaypoints(
+    const YAML::Node& waypoint_group,
+    std::vector<geographic_msgs::msg::GeoPoint>& destination_vector
+  );
+  void transformNextWaypoint();
 
-    void setAutonCallback(std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-                          std::shared_ptr<std_srvs::srv::SetBool::Response> response);
+  // Navigation Control
+  void startNavigation();
+  void stopNavigation();
+  void resetNavigation();
 
-    void resetAutonCallback(std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-                          std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+  NavigateToPose::Goal buildNavigateToPoseGoal(
+    const geometry_msgs::msg::Point& localized_waypoint
+  );
+  void navigateToWaypoint(const geometry_msgs::msg::Point& localized_waypoint);
 
-    void setCourseCallback(std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-                          std::shared_ptr<std_srvs::srv::SetBool::Response> response);
+  // Waypoints
+  bool practice_course_ = false;
+  std::vector<geographic_msgs::msg::GeoPoint> practice_course_waypoints_;
+  std::vector<geographic_msgs::msg::GeoPoint> main_course_waypoints_;
+  std::vector<geographic_msgs::msg::GeoPoint> selected_waypoints_;
 
-    // Waypoints
-    bool practiceCourse_ = false;
-    std::vector<geographic_msgs::msg::GeoPoint> practice_course_waypoints_;
-    std::vector<geographic_msgs::msg::GeoPoint> main_course_waypoints_;
-    std::vector<geographic_msgs::msg::GeoPoint> selected_waypoints_;
+  std::vector<geometry_msgs::msg::Point> localized_waypoints_;
 
-    std::vector<geometry_msgs::msg::Point> localized_waypoints_;
+  // Track auton state
+  bool enable_follower_ = false;
+  size_t waypoint_transform_index_ = 0;
 
-    // Track auton state
-    bool enableFollower_ = false;
-    size_t waypoint_transform_index_ = 0;
+  // Track which waypoint is currently being navigated to
+  bool waypoints_configured_ = false;
+  size_t current_waypoint_index_ = 0;
+  size_t retry_events_ = 0;
 
-    // Track which waypoint is currently being navigated to
-    bool waypointsConfigured_ = false;
-    size_t current_waypoint_index_ = 0;
+  // Service Callbacks
+  void setAutonCallback(
+    const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+    std::shared_ptr<std_srvs::srv::SetBool::Response> response
+  );
 
-    // Service Client
-    rclcpp::Client<fusioncore_ros::srv::FromLL>::SharedPtr from_ll_client_;
+  void resetAutonCallback(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> response
+  );
 
-    // Services
-    rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_auton_srv_;
-    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reset_auton_srv_;
-    rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_course_srv_;
+  void setCourseCallback(
+    const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+    std::shared_ptr<std_srvs::srv::SetBool::Response> response
+  );
 
-    // Action Client
-    rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SharedPtr nav_to_pose_client_;
-    rclcpp_action::ClientGoalHandle<nav2_msgs::action::NavigateToPose>::SharedPtr current_goal_handle_;
+  void fromLLCallback(
+    geographic_msgs::msg::GeoPoint waypoint,
+    rclcpp::Client<fusioncore_ros::srv::FromLL>::SharedFuture future_response
+  );
+
+  // Action Callbacks
+  void navGoalResponseCallback(
+    const rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr& goal_handle
+  );
+
+  void navGoalFeedbackCallback(
+    rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr,
+    const std::shared_ptr<const NavigateToPose::Feedback> feedback
+  );
+
+  void navGoalResultCallback(
+    const rclcpp_action::ClientGoalHandle<NavigateToPose>::WrappedResult& result
+  );
+
+  void navCancelGoalCallback(
+    const std::shared_ptr<action_msgs::srv::CancelGoal_Response>& cancel_response
+  );
+
+  // Service Client
+  rclcpp::Client<fusioncore_ros::srv::FromLL>::SharedPtr from_ll_client_;
+
+  // Services
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_auton_srv_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reset_auton_srv_;
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_course_srv_;
+
+  // Action Client
+  rclcpp_action::Client<NavigateToPose>::SharedPtr nav_to_pose_client_;
+  rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr current_goal_handle_;
 };
 
 #endif

--- a/ora_navigation/include/gps_waypoint_follower.hpp
+++ b/ora_navigation/include/gps_waypoint_follower.hpp
@@ -4,10 +4,10 @@
 #include <chrono>
 #include <memory>
 #include <string>
-#include <fstream>
 #include <yaml-cpp/yaml.h>
 
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
 #include <ament_index_cpp/get_package_share_directory.hpp>
 
 #include "nav2_msgs/action/navigate_to_pose.hpp"
@@ -17,8 +17,7 @@
 #include "geometry_msgs/msg/point.hpp"
 
 #include "std_srvs/srv/set_bool.hpp"
-
-#include "std_msgs/msg/string.hpp"
+#include "std_srvs/srv/trigger.hpp"
 
 class GpsWaypointFollower : public rclcpp::Node
 {
@@ -28,19 +27,23 @@ class GpsWaypointFollower : public rclcpp::Node
   private:
     void initialize(const YAML::Node& config);
     void loadWaypoints(const YAML::Node& waypoint_group, std::vector<geographic_msgs::msg::GeoPoint>& destination_vector);
-    bool localizeWaypoints(const std::vector<geographic_msgs::msg::GeoPoint>& known_gps_waypoints);
     void transformNextWaypoint();
+
+    void startNavigation();
+    void stopNavigation();
+    void resetNavigation();
+    void navigateToWaypoint(const geometry_msgs::msg::Point& localized_waypoint);
 
     void setAutonCallback(std::shared_ptr<std_srvs::srv::SetBool::Request> request,
                           std::shared_ptr<std_srvs::srv::SetBool::Response> response);
 
+    void resetAutonCallback(std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                          std::shared_ptr<std_srvs::srv::Trigger::Response> response);
+
     void setCourseCallback(std::shared_ptr<std_srvs::srv::SetBool::Request> request,
                           std::shared_ptr<std_srvs::srv::SetBool::Response> response);
 
-    rclcpp::TimerBase::SharedPtr waypoint_init_timer_;
-
-    rclcpp::Client<fusioncore_ros::srv::FromLL>::SharedPtr from_ll_client_;
-
+    // Waypoints
     bool practiceCourse_ = false;
     std::vector<geographic_msgs::msg::GeoPoint> practice_course_waypoints_;
     std::vector<geographic_msgs::msg::GeoPoint> main_course_waypoints_;
@@ -48,12 +51,25 @@ class GpsWaypointFollower : public rclcpp::Node
 
     std::vector<geometry_msgs::msg::Point> localized_waypoints_;
 
+    // Track auton state
     bool enableFollower_ = false;
-    size_t waypoint_transform_index_;
+    size_t waypoint_transform_index_ = 0;
 
-    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr temp_publisher_;
+    // Track which waypoint is currently being navigated to
+    bool waypointsConfigured_ = false;
+    size_t current_waypoint_index_ = 0;
+
+    // Service Client
+    rclcpp::Client<fusioncore_ros::srv::FromLL>::SharedPtr from_ll_client_;
+
+    // Services
     rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_auton_srv_;
+    rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reset_auton_srv_;
     rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_course_srv_;
+
+    // Action Client
+    rclcpp_action::Client<nav2_msgs::action::NavigateToPose>::SharedPtr nav_to_pose_client_;
+    rclcpp_action::ClientGoalHandle<nav2_msgs::action::NavigateToPose>::SharedPtr current_goal_handle_;
 };
 
 #endif

--- a/ora_navigation/include/gps_waypoint_follower.hpp
+++ b/ora_navigation/include/gps_waypoint_follower.hpp
@@ -1,0 +1,15 @@
+#ifndef GPS_WAYPOINT_FOLLOWER
+#define GPS_WAYPOINT_FOLLOWER
+
+#include "rclcpp/rclcpp.hpp"
+
+class GpsWaypointFollower : public rclcpp::Node
+{
+  public:
+    GpsWaypointFollower();
+
+  private:
+
+};
+
+#endif

--- a/ora_navigation/include/gps_waypoint_follower.hpp
+++ b/ora_navigation/include/gps_waypoint_follower.hpp
@@ -1,7 +1,24 @@
 #ifndef GPS_WAYPOINT_FOLLOWER
 #define GPS_WAYPOINT_FOLLOWER
 
+#include <chrono>
+#include <memory>
+#include <string>
+#include <fstream>
+#include <yaml-cpp/yaml.h>
+
 #include "rclcpp/rclcpp.hpp"
+#include <ament_index_cpp/get_package_share_directory.hpp>
+
+#include "nav2_msgs/action/navigate_to_pose.hpp"
+
+#include "fusioncore_ros/srv/from_ll.hpp"
+#include "geographic_msgs/msg/geo_point.hpp"
+#include "geometry_msgs/msg/point.hpp"
+
+#include "std_srvs/srv/set_bool.hpp"
+
+#include "std_msgs/msg/string.hpp"
 
 class GpsWaypointFollower : public rclcpp::Node
 {
@@ -9,7 +26,34 @@ class GpsWaypointFollower : public rclcpp::Node
     GpsWaypointFollower();
 
   private:
+    void initialize(const YAML::Node& config);
+    void loadWaypoints(const YAML::Node& waypoint_group, std::vector<geographic_msgs::msg::GeoPoint>& destination_vector);
+    bool localizeWaypoints(const std::vector<geographic_msgs::msg::GeoPoint>& known_gps_waypoints);
+    void transformNextWaypoint();
 
+    void setAutonCallback(std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                          std::shared_ptr<std_srvs::srv::SetBool::Response> response);
+
+    void setCourseCallback(std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                          std::shared_ptr<std_srvs::srv::SetBool::Response> response);
+
+    rclcpp::TimerBase::SharedPtr waypoint_init_timer_;
+
+    rclcpp::Client<fusioncore_ros::srv::FromLL>::SharedPtr from_ll_client_;
+
+    bool practiceCourse_ = false;
+    std::vector<geographic_msgs::msg::GeoPoint> practice_course_waypoints_;
+    std::vector<geographic_msgs::msg::GeoPoint> main_course_waypoints_;
+    std::vector<geographic_msgs::msg::GeoPoint> selected_waypoints_;
+
+    std::vector<geometry_msgs::msg::Point> localized_waypoints_;
+
+    bool enableFollower_ = false;
+    size_t waypoint_transform_index_;
+
+    rclcpp::Publisher<std_msgs::msg::String>::SharedPtr temp_publisher_;
+    rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_auton_srv_;
+    rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr set_course_srv_;
 };
 
 #endif

--- a/ora_navigation/launch/nav.launch.yaml
+++ b/ora_navigation/launch/nav.launch.yaml
@@ -12,3 +12,11 @@ launch:
         value: "$(find-pkg-share ora_navigation)/config/nav2_params.yaml"
       - name: "use_sim_time"
         value: "$(var use_sim_time)"
+
+- node:
+    pkg: "ora_navigation"
+    exec: "gps_waypoint_follower"
+    output: "screen"
+    param:
+      - name: "use_sim_time"
+        value: "$(var use_sim_time)"

--- a/ora_navigation/package.xml
+++ b/ora_navigation/package.xml
@@ -9,6 +9,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>rclcpp</depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/ora_navigation/package.xml
+++ b/ora_navigation/package.xml
@@ -10,6 +10,13 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>ament_index_cpp</depend>
+  <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
+  <depend>fusioncore_ros</depend>
+  <depend>geographic_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav2_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/ora_navigation/package.xml
+++ b/ora_navigation/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
   <depend>ament_index_cpp</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>

--- a/ora_navigation/src/gps_waypoint_follower.cpp
+++ b/ora_navigation/src/gps_waypoint_follower.cpp
@@ -2,6 +2,207 @@
 
 GpsWaypointFollower::GpsWaypointFollower() : Node("gps_waypoint_follower")
 {
+  const auto package_share_dir = ament_index_cpp::get_package_share_directory("ora_navigation");
 
+  this->declare_parameter("waypoints_file", package_share_dir + "/config/waypoints.yaml");
+
+  const auto waypoints_file = this->get_parameter("waypoints_file").as_string();
+
+  from_ll_client_ = this->create_client<fusioncore_ros::srv::FromLL>("/fromLL");
+
+  set_auton_srv_ = this->create_service<std_srvs::srv::SetBool>("navigation/set_auton",
+                        std::bind(&GpsWaypointFollower::setAutonCallback, this, std::placeholders::_1, std::placeholders::_2));
+  set_course_srv_ = this->create_service<std_srvs::srv::SetBool>("navigation/set_course",
+                        std::bind(&GpsWaypointFollower::setCourseCallback, this, std::placeholders::_1, std::placeholders::_2));
+
+  const YAML::Node config_file = YAML::LoadFile(waypoints_file);
+  initialize(config_file);
 }
 
+void GpsWaypointFollower::initialize(const YAML::Node& config)
+{
+  practice_course_waypoints_.clear();
+  main_course_waypoints_.clear();
+
+  loadWaypoints(config["practice_course"], practice_course_waypoints_);
+  loadWaypoints(config["main_course"], main_course_waypoints_);
+}
+
+/**
+ * Load waypoints from the `waypoint_group` file into the `destination_vector`
+ */
+void GpsWaypointFollower::loadWaypoints(const YAML::Node& waypoint_group, std::vector<geographic_msgs::msg::GeoPoint>& destination_vector)
+{
+  if (!waypoint_group || !waypoint_group.IsSequence())
+  {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "Waypoint group is missing or is not a list."
+    );
+    return;
+  }
+
+  for (const auto& waypoint : waypoint_group)
+  {
+    const auto name = waypoint["name"] ? waypoint["name"].as<std::string>() : "Unnamed";
+
+    if (!waypoint["lat"] || !waypoint["lon"])
+    {
+      RCLCPP_WARN(
+        this->get_logger(),
+        "Waypoint %s is missing lat or lon, skipping...",
+        name.c_str()
+      );
+      continue;
+    }
+
+    geographic_msgs::msg::GeoPoint navWaypoint;
+    navWaypoint.latitude = waypoint["lat"].as<double>();
+    navWaypoint.longitude = waypoint["lon"].as<double>();
+
+    destination_vector.push_back(navWaypoint);
+  }
+
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Waypoint group loaded."
+  );
+}
+
+/**
+ * Use the `/fromLL` service from `fusioncore_ros` to transform a waypoint from GPS to the local coordinate system
+ */
+void GpsWaypointFollower::transformNextWaypoint()
+{
+  if (!from_ll_client_->service_is_ready())
+  {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "/fromLL service is not available yet."
+    );
+    return;
+  }
+
+  if (waypoint_transform_index_ >= selected_waypoints_.size())
+  {
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Successfully transformed %zu GPS waypoints.",
+      localized_waypoints_.size()
+    );
+
+    // Start navigation after transforming all points
+    // startNavigation();
+
+    return;
+  }
+
+  const auto waypoint = selected_waypoints_[waypoint_transform_index_];
+
+  auto request = std::make_shared<fusioncore_ros::srv::FromLL::Request>();
+  request->ll_point = waypoint;
+
+  from_ll_client_->async_send_request(
+    request,
+    [this, waypoint](
+      rclcpp::Client<fusioncore_ros::srv::FromLL>::SharedFuture future_response)
+    {
+      const auto response = future_response.get();
+      const auto& point = response->map_point;
+
+      if ((point.x == 0.0) && (point.y == 0.0) && (point.z == 0.0))
+      {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "FusionCore returned (0, 0, 0). GPS reference may not be set. Waypoint lat=%f, lon=%f was not added.",
+          waypoint.latitude,
+          waypoint.longitude
+        );
+
+        enableFollower_ = false;
+        return;
+      }
+
+      localized_waypoints_.push_back(point);
+
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Converted GPS waypoint lat=%f, lon=%f -> x=%.3f, y=%.3f",
+        waypoint.latitude,
+        waypoint.longitude,
+        point.x,
+        point.y
+      );
+
+      ++waypoint_transform_index_;
+      transformNextWaypoint();
+    }
+  );
+}
+
+
+/**
+ * `request->data: false` - Autonomous control disabled
+ * `request->data: true` - Autonomous control enabled
+ */
+void GpsWaypointFollower::setAutonCallback(std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                           std::shared_ptr<std_srvs::srv::SetBool::Response> response)
+{
+  enableFollower_ = request->data;
+  response->success = true;
+
+  if (!enableFollower_)
+  {
+    response->message = "Waypoint follower disabled";
+    return;
+  }
+
+  selected_waypoints_ = practiceCourse_ ? practice_course_waypoints_ : main_course_waypoints_;
+  waypoint_transform_index_ = 0;
+  localized_waypoints_.clear();
+
+  response->message = "Waypoint follower enabled";
+
+  transformNextWaypoint();
+}
+
+/**
+ * `request->data: false` - Main Course in use
+ * `request->data: true` - Practice Course in use
+ */
+void GpsWaypointFollower::setCourseCallback(std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+                                           std::shared_ptr<std_srvs::srv::SetBool::Response> response)
+{
+  practiceCourse_ = request->data;
+  response->success = true;
+
+  if (practiceCourse_)
+  {
+    response->message = "Practice Course Waypoint Navigation";
+
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Practice course navigation enabled"
+    );
+  }
+  else
+  {
+    response->message = "Main Course Waypoint Navigation";
+
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Main course navigation enabled"
+    );
+  }
+}
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<GpsWaypointFollower>();
+  rclcpp::spin(node);
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ora_navigation/src/gps_waypoint_follower.cpp
+++ b/ora_navigation/src/gps_waypoint_follower.cpp
@@ -1,5 +1,7 @@
 #include "../include/gps_waypoint_follower.hpp"
 
+using NavigateToPose = nav2_msgs::action::NavigateToPose;
+
 GpsWaypointFollower::GpsWaypointFollower() : Node("gps_waypoint_follower")
 {
   const auto package_share_dir = ament_index_cpp::get_package_share_directory("ora_navigation");
@@ -8,12 +10,19 @@ GpsWaypointFollower::GpsWaypointFollower() : Node("gps_waypoint_follower")
 
   const auto waypoints_file = this->get_parameter("waypoints_file").as_string();
 
-  from_ll_client_ = this->create_client<fusioncore_ros::srv::FromLL>("/fromLL");
-
+  // Service
   set_auton_srv_ = this->create_service<std_srvs::srv::SetBool>("navigation/set_auton",
                         std::bind(&GpsWaypointFollower::setAutonCallback, this, std::placeholders::_1, std::placeholders::_2));
+  reset_auton_srv_ = this->create_service<std_srvs::srv::Trigger>("navigation/reset_auton",
+                        std::bind(&GpsWaypointFollower::resetAutonCallback, this, std::placeholders::_1, std::placeholders::_2));
   set_course_srv_ = this->create_service<std_srvs::srv::SetBool>("navigation/set_course",
                         std::bind(&GpsWaypointFollower::setCourseCallback, this, std::placeholders::_1, std::placeholders::_2));
+
+  // Service Client
+  from_ll_client_ = this->create_client<fusioncore_ros::srv::FromLL>("/fromLL");
+
+  // Action Client
+  nav_to_pose_client_ = rclcpp_action::create_client<NavigateToPose>(this, "/navigate_to_pose");
 
   const YAML::Node config_file = YAML::LoadFile(waypoints_file);
   initialize(config_file);
@@ -23,6 +32,8 @@ void GpsWaypointFollower::initialize(const YAML::Node& config)
 {
   practice_course_waypoints_.clear();
   main_course_waypoints_.clear();
+
+  current_waypoint_index_ = 0;
 
   loadWaypoints(config["practice_course"], practice_course_waypoints_);
   loadWaypoints(config["main_course"], main_course_waypoints_);
@@ -91,8 +102,7 @@ void GpsWaypointFollower::transformNextWaypoint()
       localized_waypoints_.size()
     );
 
-    // Start navigation after transforming all points
-    // startNavigation();
+    startNavigation();
 
     return;
   }
@@ -140,6 +150,250 @@ void GpsWaypointFollower::transformNextWaypoint()
   );
 }
 
+void GpsWaypointFollower::startNavigation()
+{
+  if (localized_waypoints_.empty())
+  {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "No localized waypoints available"
+    );
+
+    return;
+  }
+
+  // Waypoint navigation complete
+  if (current_waypoint_index_ >= localized_waypoints_.size())
+  {
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Successfully navigated to all waypoints. Resetting navigation to first waypoint."
+    );
+
+    resetNavigation();
+    enableFollower_ = false;
+    return;
+  }
+
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Starting navigation to waypoint %zu",
+    current_waypoint_index_
+  );
+
+  navigateToWaypoint(localized_waypoints_[current_waypoint_index_]);
+}
+
+/**
+ * Cancel the current Nav2 goal
+ * Does not restart navigation from the beginning unless `resetNavigation()` is called in tandem
+ */
+void GpsWaypointFollower::stopNavigation()
+{
+  enableFollower_ = false;
+
+  if (!current_goal_handle_)
+  {
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Waypoint follower stopped. No active goal to cancel."
+    );
+    return;
+  }
+
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Canceling active Nav2 goal."
+  );
+
+  nav_to_pose_client_->async_cancel_goal(
+    current_goal_handle_,
+    [this](const auto& future)
+    {
+      const auto cancel_response = future.get();
+
+      if (cancel_response->return_code == action_msgs::srv::CancelGoal::Response::ERROR_NONE)
+      {
+        RCLCPP_INFO(
+          this->get_logger(),
+          "Nav2 goal cancelled successfully"
+        );
+      }
+      else
+      {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "Nav2 goal cancelled with an error. Return code: %d",
+          cancel_response->return_code
+        );
+      }
+
+      current_goal_handle_.reset();
+    }
+  );
+}
+
+/**
+ * Allow waypoints to be reconfigured
+ * Reset the current goal to first waypoint
+ */
+void GpsWaypointFollower::resetNavigation()
+{
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Waypoint navigation reset"
+  );
+
+  waypointsConfigured_ = false;
+  waypoint_transform_index_ = 0;
+
+  current_waypoint_index_ = 0;
+}
+
+void GpsWaypointFollower::navigateToWaypoint(const geometry_msgs::msg::Point& localizedWaypoint)
+{
+  if (!this->nav_to_pose_client_->wait_for_action_server())
+  {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Action server not available"
+    );
+    return;
+  }
+
+  auto goal_msg = NavigateToPose::Goal();
+
+  // Set goal position to localized waypoint
+  goal_msg.pose.header.frame_id = "odom";
+  goal_msg.pose.header.stamp = this->get_clock()->now();
+  goal_msg.pose.pose.position.x = localizedWaypoint.x;
+  goal_msg.pose.pose.position.y = localizedWaypoint.y;
+  goal_msg.pose.pose.position.z = localizedWaypoint.z;
+
+  // Set goal orientation to an arbitrary value, our parameters shouldn't require orientation
+  goal_msg.pose.pose.orientation.x = 0;
+  goal_msg.pose.pose.orientation.y = 0;
+  goal_msg.pose.pose.orientation.z = 0;
+  goal_msg.pose.pose.orientation.w = 1;
+
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Sending goal to navigate to {x: %.2f, y: %.2f}",
+    goal_msg.pose.pose.position.x, goal_msg.pose.pose.position.y
+  );
+
+  auto send_goal_options = rclcpp_action::Client<NavigateToPose>::SendGoalOptions();
+  send_goal_options.goal_response_callback = [this](const rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr& goal_handle)
+  {
+    if (!goal_handle)
+    {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Goal was rejected by server"
+      );
+
+      enableFollower_ = false;
+      return;
+    }
+
+    current_goal_handle_ = goal_handle;
+
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Goal was accepted by server, waiting for result"
+    );
+  };
+
+  // Feedback Callback
+  // We don't particularly need the feedback, but we will log the current pose and distance remaining
+  send_goal_options.feedback_callback = [this](rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr,
+                                               const std::shared_ptr<const NavigateToPose::Feedback> feedback)
+  {
+    RCLCPP_INFO(
+      this->get_logger(),
+      "current_pose: x:%.2f, y:%.2f, distance_remaining:%.2f",
+      feedback->current_pose.pose.position.x, feedback->current_pose.pose.position.y, feedback->distance_remaining
+    );
+  };
+
+  // Result Callback
+  // Nav2 only provides error codes for results. If there is no error break and continue, otherwise log the error
+  send_goal_options.result_callback = [this](const rclcpp_action::ClientGoalHandle<NavigateToPose>::WrappedResult& result)
+  {
+    current_goal_handle_.reset();
+
+    if (!enableFollower_)
+    {
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Waypoint follower is disabled, ignoring Nav2 result"
+      );
+      return;
+    }
+
+    switch (result.code)
+    {
+      case rclcpp_action::ResultCode::SUCCEEDED:
+      {
+        RCLCPP_INFO(
+          this->get_logger(),
+          "Reached waypoint %zu",
+          current_waypoint_index_ + 1
+        );
+
+        ++current_waypoint_index_;
+
+        // Successfully navigated to all waypoints
+        if (current_waypoint_index_ >= localized_waypoints_.size())
+        {
+          RCLCPP_INFO(
+            this->get_logger(),
+            "Navigation complete"
+          );
+
+          enableFollower_ = false;
+          return;
+        }
+
+        // Navigate to next point
+        navigateToWaypoint(localized_waypoints_[current_waypoint_index_]);
+        return;
+      }
+      case rclcpp_action::ResultCode::CANCELED:
+      {
+        RCLCPP_INFO(
+          this->get_logger(),
+          "Waypoint navigation goal canceled"
+        );
+        return;
+      }
+      case rclcpp_action::ResultCode::ABORTED:
+      {
+        RCLCPP_ERROR(
+          this->get_logger(),
+          "Navigation goal was aborted by Nav2"
+        );
+
+        enableFollower_ = false;
+        return;
+      }
+      default:
+      {
+        RCLCPP_ERROR(
+            this->get_logger(),
+            "Finished with unknown result code"
+          );
+
+          enableFollower_ = false;
+          return;
+      }
+    }
+  };
+
+  // Send the goal
+  this->nav_to_pose_client_->async_send_goal(goal_msg, send_goal_options);
+  return;
+}
 
 /**
  * `request->data: false` - Autonomous control disabled
@@ -149,21 +403,52 @@ void GpsWaypointFollower::setAutonCallback(std::shared_ptr<std_srvs::srv::SetBoo
                                            std::shared_ptr<std_srvs::srv::SetBool::Response> response)
 {
   enableFollower_ = request->data;
-  response->success = true;
 
   if (!enableFollower_)
   {
+    stopNavigation();
+
+    response->success = true;
     response->message = "Waypoint follower disabled";
     return;
   }
 
-  selected_waypoints_ = practiceCourse_ ? practice_course_waypoints_ : main_course_waypoints_;
-  waypoint_transform_index_ = 0;
-  localized_waypoints_.clear();
+  if (!waypointsConfigured_)
+  {
+    // Get vector of waypoints
+    selected_waypoints_ = practiceCourse_ ? practice_course_waypoints_ : main_course_waypoints_;
 
-  response->message = "Waypoint follower enabled";
+    // Reset waypoint index and vector
+    waypoint_transform_index_ = 0;
+    localized_waypoints_.clear();
+    waypointsConfigured_ = true;
 
-  transformNextWaypoint();
+    response->success = true;
+    response->message = "Waypoint follower enabled, transforming waypoints";
+
+    transformNextWaypoint();
+    return;
+  }
+
+  response->success = true;
+  response->message = "Waypoint follower enabled, resuming navigation";
+
+  startNavigation();
+}
+
+/**
+ * Sending a `Trigger` request sets navigation back to initial values
+ */
+void GpsWaypointFollower::resetAutonCallback(std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+                                           std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+{
+  (void) request;
+
+  stopNavigation();
+  resetNavigation();
+
+  response->success = true;
+  response->message = "Reset navigation values.";
 }
 
 /**
@@ -175,6 +460,11 @@ void GpsWaypointFollower::setCourseCallback(std::shared_ptr<std_srvs::srv::SetBo
 {
   practiceCourse_ = request->data;
   response->success = true;
+
+  waypointsConfigured_ = false;
+  current_waypoint_index_ = 0;
+  waypoint_transform_index_ = 0;
+  localized_waypoints_.clear();
 
   if (practiceCourse_)
   {

--- a/ora_navigation/src/gps_waypoint_follower.cpp
+++ b/ora_navigation/src/gps_waypoint_follower.cpp
@@ -1,0 +1,7 @@
+#include "../include/gps_waypoint_follower.hpp"
+
+GpsWaypointFollower::GpsWaypointFollower() : Node("gps_waypoint_follower")
+{
+
+}
+

--- a/ora_navigation/src/gps_waypoint_follower.cpp
+++ b/ora_navigation/src/gps_waypoint_follower.cpp
@@ -5,18 +5,45 @@ using NavigateToPose = nav2_msgs::action::NavigateToPose;
 GpsWaypointFollower::GpsWaypointFollower() : Node("gps_waypoint_follower")
 {
   const auto package_share_dir = ament_index_cpp::get_package_share_directory("ora_navigation");
+  const std::string default_waypoint_file = package_share_dir + "/config/waypoints.yaml";
 
-  this->declare_parameter("waypoints_file", package_share_dir + "/config/waypoints.yaml");
+  this->declare_parameter("waypoints_file", default_waypoint_file);
 
   const auto waypoints_file = this->get_parameter("waypoints_file").as_string();
 
-  // Service
-  set_auton_srv_ = this->create_service<std_srvs::srv::SetBool>("navigation/set_auton",
-                        std::bind(&GpsWaypointFollower::setAutonCallback, this, std::placeholders::_1, std::placeholders::_2));
-  reset_auton_srv_ = this->create_service<std_srvs::srv::Trigger>("navigation/reset_auton",
-                        std::bind(&GpsWaypointFollower::resetAutonCallback, this, std::placeholders::_1, std::placeholders::_2));
-  set_course_srv_ = this->create_service<std_srvs::srv::SetBool>("navigation/set_course",
-                        std::bind(&GpsWaypointFollower::setCourseCallback, this, std::placeholders::_1, std::placeholders::_2));
+  // Create services and assign callbacks
+  set_auton_srv_ = this->create_service<std_srvs::srv::SetBool>(
+    "navigation/set_auton",
+    [this](
+      const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+      std::shared_ptr<std_srvs::srv::SetBool::Response> response
+    )
+    {
+      setAutonCallback(request, response);
+    }
+  );
+
+  reset_auton_srv_ = this->create_service<std_srvs::srv::Trigger>(
+    "navigation/reset_auton",
+    [this](
+      const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+      std::shared_ptr<std_srvs::srv::Trigger::Response> response
+    )
+    {
+      resetAutonCallback(request, response);
+    }
+  );
+
+  set_course_srv_ = this->create_service<std_srvs::srv::SetBool>(
+    "navigation/set_course",
+    [this](
+      const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+      std::shared_ptr<std_srvs::srv::SetBool::Response> response
+    )
+    {
+      setCourseCallback(request, response);
+    }
+  );
 
   // Service Client
   from_ll_client_ = this->create_client<fusioncore_ros::srv::FromLL>("/fromLL");
@@ -42,7 +69,10 @@ void GpsWaypointFollower::initialize(const YAML::Node& config)
 /**
  * Load waypoints from the `waypoint_group` file into the `destination_vector`
  */
-void GpsWaypointFollower::loadWaypoints(const YAML::Node& waypoint_group, std::vector<geographic_msgs::msg::GeoPoint>& destination_vector)
+void GpsWaypointFollower::loadWaypoints(
+  const YAML::Node& waypoint_group,
+  std::vector<geographic_msgs::msg::GeoPoint>& destination_vector
+)
 {
   if (!waypoint_group || !waypoint_group.IsSequence())
   {
@@ -67,11 +97,11 @@ void GpsWaypointFollower::loadWaypoints(const YAML::Node& waypoint_group, std::v
       continue;
     }
 
-    geographic_msgs::msg::GeoPoint navWaypoint;
-    navWaypoint.latitude = waypoint["lat"].as<double>();
-    navWaypoint.longitude = waypoint["lon"].as<double>();
+    geographic_msgs::msg::GeoPoint nav_waypoint;
+    nav_waypoint.latitude = waypoint["lat"].as<double>();
+    nav_waypoint.longitude = waypoint["lon"].as<double>();
 
-    destination_vector.push_back(navWaypoint);
+    destination_vector.push_back(nav_waypoint);
   }
 
   RCLCPP_INFO(
@@ -81,7 +111,8 @@ void GpsWaypointFollower::loadWaypoints(const YAML::Node& waypoint_group, std::v
 }
 
 /**
- * Use the `/fromLL` service from `fusioncore_ros` to transform a waypoint from GPS to the local coordinate system
+ * Use the `/fromLL` service from `fusioncore_ros` to
+ * transform a waypoint from GPS to the local coordinate system
  */
 void GpsWaypointFollower::transformNextWaypoint()
 {
@@ -115,37 +146,10 @@ void GpsWaypointFollower::transformNextWaypoint()
   from_ll_client_->async_send_request(
     request,
     [this, waypoint](
-      rclcpp::Client<fusioncore_ros::srv::FromLL>::SharedFuture future_response)
+      rclcpp::Client<fusioncore_ros::srv::FromLL>::SharedFuture future_response
+    )
     {
-      const auto response = future_response.get();
-      const auto& point = response->map_point;
-
-      if ((point.x == 0.0) && (point.y == 0.0) && (point.z == 0.0))
-      {
-        RCLCPP_WARN(
-          this->get_logger(),
-          "FusionCore returned (0, 0, 0). GPS reference may not be set. Waypoint lat=%f, lon=%f was not added.",
-          waypoint.latitude,
-          waypoint.longitude
-        );
-
-        enableFollower_ = false;
-        return;
-      }
-
-      localized_waypoints_.push_back(point);
-
-      RCLCPP_INFO(
-        this->get_logger(),
-        "Converted GPS waypoint lat=%f, lon=%f -> x=%.3f, y=%.3f",
-        waypoint.latitude,
-        waypoint.longitude,
-        point.x,
-        point.y
-      );
-
-      ++waypoint_transform_index_;
-      transformNextWaypoint();
+      fromLLCallback(waypoint, future_response);
     }
   );
 }
@@ -171,7 +175,7 @@ void GpsWaypointFollower::startNavigation()
     );
 
     resetNavigation();
-    enableFollower_ = false;
+    enable_follower_ = false;
     return;
   }
 
@@ -190,7 +194,7 @@ void GpsWaypointFollower::startNavigation()
  */
 void GpsWaypointFollower::stopNavigation()
 {
-  enableFollower_ = false;
+  enable_follower_ = false;
 
   if (!current_goal_handle_)
   {
@@ -208,27 +212,11 @@ void GpsWaypointFollower::stopNavigation()
 
   nav_to_pose_client_->async_cancel_goal(
     current_goal_handle_,
-    [this](const auto& future)
+    [this](
+      const rclcpp_action::Client<NavigateToPose>::CancelResponse::SharedPtr cancel_response
+    )
     {
-      const auto cancel_response = future.get();
-
-      if (cancel_response->return_code == action_msgs::srv::CancelGoal::Response::ERROR_NONE)
-      {
-        RCLCPP_INFO(
-          this->get_logger(),
-          "Nav2 goal cancelled successfully"
-        );
-      }
-      else
-      {
-        RCLCPP_WARN(
-          this->get_logger(),
-          "Nav2 goal cancelled with an error. Return code: %d",
-          cancel_response->return_code
-        );
-      }
-
-      current_goal_handle_.reset();
+      navCancelGoalCallback(cancel_response);
     }
   );
 }
@@ -244,13 +232,36 @@ void GpsWaypointFollower::resetNavigation()
     "Waypoint navigation reset"
   );
 
-  waypointsConfigured_ = false;
+  waypoints_configured_ = false;
   waypoint_transform_index_ = 0;
 
   current_waypoint_index_ = 0;
 }
 
-void GpsWaypointFollower::navigateToWaypoint(const geometry_msgs::msg::Point& localizedWaypoint)
+NavigateToPose::Goal GpsWaypointFollower::buildNavigateToPoseGoal(
+  const geometry_msgs::msg::Point& localized_waypoint
+)
+{
+  // Create a goal message
+  auto goal_msg = NavigateToPose::Goal();
+
+  // Set goal position to localized waypoint
+  goal_msg.pose.header.frame_id = "odom";
+  goal_msg.pose.header.stamp = this->get_clock()->now();
+  goal_msg.pose.pose.position.x = localized_waypoint.x;
+  goal_msg.pose.pose.position.y = localized_waypoint.y;
+  goal_msg.pose.pose.position.z = localized_waypoint.z;
+
+  // Set goal orientation to an arbitrary value, our parameters shouldn't require orientation
+  goal_msg.pose.pose.orientation.x = 0;
+  goal_msg.pose.pose.orientation.y = 0;
+  goal_msg.pose.pose.orientation.z = 0;
+  goal_msg.pose.pose.orientation.w = 1;
+
+  return goal_msg;
+}
+
+void GpsWaypointFollower::navigateToWaypoint(const geometry_msgs::msg::Point& localized_waypoint)
 {
   if (!this->nav_to_pose_client_->wait_for_action_server())
   {
@@ -261,20 +272,7 @@ void GpsWaypointFollower::navigateToWaypoint(const geometry_msgs::msg::Point& lo
     return;
   }
 
-  auto goal_msg = NavigateToPose::Goal();
-
-  // Set goal position to localized waypoint
-  goal_msg.pose.header.frame_id = "odom";
-  goal_msg.pose.header.stamp = this->get_clock()->now();
-  goal_msg.pose.pose.position.x = localizedWaypoint.x;
-  goal_msg.pose.pose.position.y = localizedWaypoint.y;
-  goal_msg.pose.pose.position.z = localizedWaypoint.z;
-
-  // Set goal orientation to an arbitrary value, our parameters shouldn't require orientation
-  goal_msg.pose.pose.orientation.x = 0;
-  goal_msg.pose.pose.orientation.y = 0;
-  goal_msg.pose.pose.orientation.z = 0;
-  goal_msg.pose.pose.orientation.w = 1;
+  auto goal_msg = buildNavigateToPoseGoal(localized_waypoint);
 
   RCLCPP_INFO(
     this->get_logger(),
@@ -282,112 +280,32 @@ void GpsWaypointFollower::navigateToWaypoint(const geometry_msgs::msg::Point& lo
     goal_msg.pose.pose.position.x, goal_msg.pose.pose.position.y
   );
 
+  // Goal Options
   auto send_goal_options = rclcpp_action::Client<NavigateToPose>::SendGoalOptions();
-  send_goal_options.goal_response_callback = [this](const rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr& goal_handle)
+
+  send_goal_options.goal_response_callback =
+  [this](
+    const rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr goal_handle
+  )
   {
-    if (!goal_handle)
-    {
-      RCLCPP_ERROR(
-        this->get_logger(),
-        "Goal was rejected by server"
-      );
-
-      enableFollower_ = false;
-      return;
-    }
-
-    current_goal_handle_ = goal_handle;
-
-    RCLCPP_INFO(
-      this->get_logger(),
-      "Goal was accepted by server, waiting for result"
-    );
+    navGoalResponseCallback(goal_handle);
   };
 
-  // Feedback Callback
-  // We don't particularly need the feedback, but we will log the current pose and distance remaining
-  send_goal_options.feedback_callback = [this](rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr,
-                                               const std::shared_ptr<const NavigateToPose::Feedback> feedback)
+  send_goal_options.feedback_callback =
+  [this](
+    rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr goal_handle,
+    const std::shared_ptr<const NavigateToPose::Feedback> feedback
+  )
   {
-    RCLCPP_INFO(
-      this->get_logger(),
-      "current_pose: x:%.2f, y:%.2f, distance_remaining:%.2f",
-      feedback->current_pose.pose.position.x, feedback->current_pose.pose.position.y, feedback->distance_remaining
-    );
+    navGoalFeedbackCallback(goal_handle, feedback);
   };
 
-  // Result Callback
-  // Nav2 only provides error codes for results. If there is no error break and continue, otherwise log the error
-  send_goal_options.result_callback = [this](const rclcpp_action::ClientGoalHandle<NavigateToPose>::WrappedResult& result)
+  send_goal_options.result_callback = 
+  [this](
+    const rclcpp_action::ClientGoalHandle<NavigateToPose>::WrappedResult &result
+  )
   {
-    current_goal_handle_.reset();
-
-    if (!enableFollower_)
-    {
-      RCLCPP_INFO(
-        this->get_logger(),
-        "Waypoint follower is disabled, ignoring Nav2 result"
-      );
-      return;
-    }
-
-    switch (result.code)
-    {
-      case rclcpp_action::ResultCode::SUCCEEDED:
-      {
-        RCLCPP_INFO(
-          this->get_logger(),
-          "Reached waypoint %zu",
-          current_waypoint_index_ + 1
-        );
-
-        ++current_waypoint_index_;
-
-        // Successfully navigated to all waypoints
-        if (current_waypoint_index_ >= localized_waypoints_.size())
-        {
-          RCLCPP_INFO(
-            this->get_logger(),
-            "Navigation complete"
-          );
-
-          enableFollower_ = false;
-          return;
-        }
-
-        // Navigate to next point
-        navigateToWaypoint(localized_waypoints_[current_waypoint_index_]);
-        return;
-      }
-      case rclcpp_action::ResultCode::CANCELED:
-      {
-        RCLCPP_INFO(
-          this->get_logger(),
-          "Waypoint navigation goal canceled"
-        );
-        return;
-      }
-      case rclcpp_action::ResultCode::ABORTED:
-      {
-        RCLCPP_ERROR(
-          this->get_logger(),
-          "Navigation goal was aborted by Nav2"
-        );
-
-        enableFollower_ = false;
-        return;
-      }
-      default:
-      {
-        RCLCPP_ERROR(
-            this->get_logger(),
-            "Finished with unknown result code"
-          );
-
-          enableFollower_ = false;
-          return;
-      }
-    }
+    navGoalResultCallback(result);
   };
 
   // Send the goal
@@ -399,12 +317,14 @@ void GpsWaypointFollower::navigateToWaypoint(const geometry_msgs::msg::Point& lo
  * `request->data: false` - Autonomous control disabled
  * `request->data: true` - Autonomous control enabled
  */
-void GpsWaypointFollower::setAutonCallback(std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-                                           std::shared_ptr<std_srvs::srv::SetBool::Response> response)
+void GpsWaypointFollower::setAutonCallback(
+  const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+  std::shared_ptr<std_srvs::srv::SetBool::Response> response
+)
 {
-  enableFollower_ = request->data;
+  enable_follower_ = request->data;
 
-  if (!enableFollower_)
+  if (!enable_follower_)
   {
     stopNavigation();
 
@@ -413,15 +333,15 @@ void GpsWaypointFollower::setAutonCallback(std::shared_ptr<std_srvs::srv::SetBoo
     return;
   }
 
-  if (!waypointsConfigured_)
+  if (!waypoints_configured_)
   {
     // Get vector of waypoints
-    selected_waypoints_ = practiceCourse_ ? practice_course_waypoints_ : main_course_waypoints_;
+    selected_waypoints_ = practice_course_ ? practice_course_waypoints_ : main_course_waypoints_;
 
     // Reset waypoint index and vector
     waypoint_transform_index_ = 0;
     localized_waypoints_.clear();
-    waypointsConfigured_ = true;
+    waypoints_configured_ = true;
 
     response->success = true;
     response->message = "Waypoint follower enabled, transforming waypoints";
@@ -439,8 +359,10 @@ void GpsWaypointFollower::setAutonCallback(std::shared_ptr<std_srvs::srv::SetBoo
 /**
  * Sending a `Trigger` request sets navigation back to initial values
  */
-void GpsWaypointFollower::resetAutonCallback(std::shared_ptr<std_srvs::srv::Trigger::Request> request,
-                                           std::shared_ptr<std_srvs::srv::Trigger::Response> response)
+void GpsWaypointFollower::resetAutonCallback(
+  const std::shared_ptr<std_srvs::srv::Trigger::Request> request,
+  std::shared_ptr<std_srvs::srv::Trigger::Response> response
+)
 {
   (void) request;
 
@@ -455,18 +377,20 @@ void GpsWaypointFollower::resetAutonCallback(std::shared_ptr<std_srvs::srv::Trig
  * `request->data: false` - Main Course in use
  * `request->data: true` - Practice Course in use
  */
-void GpsWaypointFollower::setCourseCallback(std::shared_ptr<std_srvs::srv::SetBool::Request> request,
-                                           std::shared_ptr<std_srvs::srv::SetBool::Response> response)
+void GpsWaypointFollower::setCourseCallback(
+  const std::shared_ptr<std_srvs::srv::SetBool::Request> request,
+  std::shared_ptr<std_srvs::srv::SetBool::Response> response
+)
 {
-  practiceCourse_ = request->data;
+  practice_course_ = request->data;
   response->success = true;
 
-  waypointsConfigured_ = false;
+  waypoints_configured_ = false;
   current_waypoint_index_ = 0;
   waypoint_transform_index_ = 0;
   localized_waypoints_.clear();
 
-  if (practiceCourse_)
+  if (practice_course_)
   {
     response->message = "Practice Course Waypoint Navigation";
 
@@ -484,6 +408,230 @@ void GpsWaypointFollower::setCourseCallback(std::shared_ptr<std_srvs::srv::SetBo
       "Main course navigation enabled"
     );
   }
+}
+
+/**
+ * Called when a message is received from the `/from_ll` service
+ */
+void GpsWaypointFollower::fromLLCallback(
+  geographic_msgs::msg::GeoPoint waypoint,
+  rclcpp::Client<fusioncore_ros::srv::FromLL>::SharedFuture future_response
+)
+{
+  const auto response = future_response.get();
+  const auto& point = response->map_point;
+
+  if ((point.x == 0.0) && (point.y == 0.0) && (point.z == 0.0))
+  {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "FusionCore returned (0, 0, 0). GPS reference may not be set. " \
+      "Waypoint lat=%f, lon=%f was not added.",
+      waypoint.latitude,
+      waypoint.longitude
+    );
+
+    enable_follower_ = false;
+    return;
+  }
+
+  localized_waypoints_.push_back(point);
+
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Converted GPS waypoint lat=%f, lon=%f -> x=%.3f, y=%.3f",
+    waypoint.latitude,
+    waypoint.longitude,
+    point.x,
+    point.y
+  );
+
+  ++waypoint_transform_index_;
+  transformNextWaypoint();
+}
+
+/**
+ * Called whenever a response is received by the `/navigate_to_pose` client
+ */
+void GpsWaypointFollower::navGoalResponseCallback(
+  const rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr& goal_handle
+)
+{
+  if (!goal_handle)
+  {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Goal was rejected by server"
+    );
+
+    enable_follower_ = false;
+    return;
+  }
+
+  current_goal_handle_ = goal_handle;
+
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Goal was accepted by server, waiting for result"
+  );
+}
+
+void GpsWaypointFollower::navGoalFeedbackCallback(
+  rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr,
+  const std::shared_ptr<const NavigateToPose::Feedback> feedback
+)
+{
+  RCLCPP_INFO_THROTTLE(
+    this->get_logger(),
+    *this->get_clock(),
+    1000,
+    "current_pose: x:%.2f, y:%.2f, distance_remaining:%.2f",
+    feedback->current_pose.pose.position.x,
+    feedback->current_pose.pose.position.y,
+    feedback->distance_remaining
+  );
+}
+
+/**
+ * Called whenever a goal is received by the `/navigate_to_pose` client
+ */
+void GpsWaypointFollower::navGoalResultCallback(
+  const rclcpp_action::ClientGoalHandle<NavigateToPose>::WrappedResult& result
+)
+{
+  current_goal_handle_.reset();
+
+  if (!enable_follower_)
+  {
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Waypoint follower is disabled, ignoring Nav2 result"
+    );
+    return;
+  }
+
+  switch (result.code)
+  {
+    // Goal successfully reached
+    case rclcpp_action::ResultCode::SUCCEEDED:
+    {
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Reached waypoint %zu",
+        current_waypoint_index_ + 1
+      );
+
+      ++current_waypoint_index_;
+
+      // Successfully navigated to all waypoints
+      if (current_waypoint_index_ >= localized_waypoints_.size())
+      {
+        RCLCPP_INFO(
+          this->get_logger(),
+          "Navigation complete"
+        );
+
+        enable_follower_ = false;
+        return;
+      }
+
+      // Navigate to next point
+      navigateToWaypoint(localized_waypoints_[current_waypoint_index_]);
+      return;
+    }
+
+    // Waypoint Cancelled
+    case rclcpp_action::ResultCode::CANCELED:
+    {
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Waypoint navigation goal canceled."
+      );
+
+      enable_follower_ = false;
+      return;
+    }
+
+    // Nav2 aborted 
+    case rclcpp_action::ResultCode::ABORTED:
+    {
+      RCLCPP_ERROR(
+        this->get_logger(),
+        "Navigation goal was aborted by Nav2"
+      );
+
+      if (!enable_follower_)
+      {
+        RCLCPP_INFO(
+          this->get_logger(),
+          "Follower not enabled, ending navigation"
+        );
+
+        return;
+      }
+
+      RCLCPP_INFO(
+        this->get_logger(),
+        "Follower still enabled, restarting navigation"
+      );
+
+      if (retry_events_ < 10)
+      {
+        // Restart navigation to current waypoint
+        retry_events_++;
+        navigateToWaypoint(localized_waypoints_[current_waypoint_index_]);
+      }
+      else
+      {
+        RCLCPP_ERROR(
+          this->get_logger(),
+          "Too many retries, aborting navigation"
+        );
+
+        retry_events_ = 0;
+        enable_follower_ = false;
+      }
+
+      return;
+    }
+
+    default:
+    {
+      RCLCPP_ERROR(
+          this->get_logger(),
+          "Finished with unknown result code"
+        );
+
+        enable_follower_ = false;
+        return;
+    }
+  } // switch (result.code)
+}
+
+/**
+ * Called whenever a cancel response is received by the `/navigate_to_pose` client
+ */
+void GpsWaypointFollower::navCancelGoalCallback(
+  const std::shared_ptr<action_msgs::srv::CancelGoal_Response>& cancel_response
+)
+{
+  if (cancel_response->return_code == action_msgs::srv::CancelGoal::Response::ERROR_NONE)
+  {
+    RCLCPP_INFO(
+      this->get_logger(),
+      "Nav2 goal cancelled successfully"
+    );
+  }
+  else
+  {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "Nav2 goal cancelled with an error. Return code: %d",
+      cancel_response->return_code
+    );
+  }
+
+  current_goal_handle_.reset();
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Added a GPS waypoint navigator that sends localized waypoint goals to Nav2's `NavigateToPose` action server.

The navigator loads waypoints from the `waypoints.yaml` file, converts them using FusionCore's `/fromLL` service, and sends them sequentially to `/navigate_to_pose`.

The current setup supports any number of waypoints under either the `practice_course` or `main_course` in the config. Courses can be selected by sending `true` for the practice course or `false` for the main course to `/navigation/set_course`.

Navigation can be started or stopped by sending `true` or `false`, respectively, to `/navigation/set_auton`. The navigator will retry up to 10 times if the `NavigateToPose` server aborts a goal. The `/navigation/reset_auton` service resets navigation back to the first waypoint, which can be used after a failed attempt or before switching courses.

Progresses #9 